### PR TITLE
test: add unit tests for JWT, zap logger, and Kafka adapters

### DIFF
--- a/adapter/logger/zapLogger/zap_test.go
+++ b/adapter/logger/zapLogger/zap_test.go
@@ -1,0 +1,42 @@
+package zapLogger
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStringToZapLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "error", input: "error"},
+		{name: "warn", input: "warn"},
+		{name: "info", input: "info"},
+		{name: "debug", input: "debug"},
+		{name: "invalid", input: "verbose", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := stringToZapLevel(tt.input)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetFunctionName(t *testing.T) {
+	file, line, fn := getFunctionName(0)
+	if file == "unknown" || line == 0 || fn == "unknown" {
+		t.Fatalf("unexpected function metadata: file=%q line=%d fn=%q", file, line, fn)
+	}
+	if !strings.Contains(fn, "getFunctionName") {
+		t.Fatalf("expected function name to include getFunctionName, got %q", fn)
+	}
+}

--- a/adapter/message/kafka/consumer/consumer_test.go
+++ b/adapter/message/kafka/consumer/consumer_test.go
@@ -1,0 +1,59 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestRouteActivation(t *testing.T) {
+	called := ""
+	c := &consumer{
+		activationSmsHandler: func(countryCode, to string, macros map[string]string) error {
+			called = "sms"
+			return nil
+		},
+		activationEmailHandler: func(to, subject string, macros map[string]string) error {
+			called = "email"
+			return nil
+		},
+	}
+
+	msg, _ := json.Marshal(message{Type: "verification-email", To: "u@example.com", Subject: "Verify"})
+	if err := c.routeActivation(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called != "email" {
+		t.Fatalf("expected email handler, got %s", called)
+	}
+
+	if err := c.routeActivation(context.Background(), []byte{}); err == nil {
+		t.Fatal("expected error for empty message")
+	}
+}
+
+func TestRoutePasswordReset(t *testing.T) {
+	called := ""
+	c := &consumer{
+		passwordResetSmsHandler: func(countryCode, to string, macros map[string]string) error {
+			called = "sms"
+			return nil
+		},
+		passwordResetEmailHandler: func(to, subject string, macros map[string]string) error {
+			called = "email"
+			return nil
+		},
+	}
+
+	msg, _ := json.Marshal(message{Type: "password-reset-sms", CountryCode: "+1", To: "123"})
+	if err := c.routePasswordReset(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called != "sms" {
+		t.Fatalf("expected sms handler, got %s", called)
+	}
+
+	if err := c.routePasswordReset(context.Background(), []byte("not-json")); err == nil {
+		t.Fatal("expected error for invalid json")
+	}
+}

--- a/adapter/message/kafka/producer/producer_test.go
+++ b/adapter/message/kafka/producer/producer_test.go
@@ -1,0 +1,87 @@
+package producer
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+type mockSyncProducer struct {
+	sentMessages []*sarama.ProducerMessage
+	err          error
+}
+
+func (m *mockSyncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+	m.sentMessages = append(m.sentMessages, msg)
+	return 0, 0, m.err
+}
+
+func (m *mockSyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error { return m.err }
+func (m *mockSyncProducer) Close() error                                      { return nil }
+func (m *mockSyncProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	return sarama.ProducerTxnFlagReady
+}
+func (m *mockSyncProducer) IsTransactional() bool { return false }
+func (m *mockSyncProducer) BeginTxn() error       { return nil }
+func (m *mockSyncProducer) CommitTxn() error      { return nil }
+func (m *mockSyncProducer) AbortTxn() error       { return nil }
+func (m *mockSyncProducer) AddOffsetsToTxn(map[string][]*sarama.PartitionOffsetMetadata, string) error {
+	return nil
+}
+func (m *mockSyncProducer) AddMessageToTxn(*sarama.ConsumerMessage, string, *string) error {
+	return nil
+}
+
+func TestPublishVerificationEmail(t *testing.T) {
+	mock := &mockSyncProducer{}
+	p := &producer{appName: "utils", producer: mock, topicVerification: "verify-topic"}
+
+	err := p.PublishVerificationEmail("user@example.com", "Verify", "Jane", "https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mock.sentMessages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(mock.sentMessages))
+	}
+
+	msg := mock.sentMessages[0]
+	if msg.Topic != "verify-topic" {
+		t.Fatalf("unexpected topic: %s", msg.Topic)
+	}
+
+	encoded, err := msg.Value.Encode()
+	if err != nil {
+		t.Fatalf("unexpected encode error: %v", err)
+	}
+
+	var got message
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("unexpected payload unmarshal error: %v", err)
+	}
+
+	if got.Type != "verification-email" || got.Macros["appName"] != "utils" {
+		t.Fatalf("unexpected payload: %+v", got)
+	}
+}
+
+func TestPublishErrors(t *testing.T) {
+	t.Run("marshal error", func(t *testing.T) {
+		p := &producer{producer: &mockSyncProducer{}}
+		err := p.publish("topic", "k", func() {})
+		if err == nil {
+			t.Fatal("expected marshal error")
+		}
+	})
+
+	t.Run("send error", func(t *testing.T) {
+		sendErr := errors.New("send failed")
+		p := &producer{producer: &mockSyncProducer{err: sendErr}}
+		err := p.publish("topic", "k", map[string]string{"x": "y"})
+		if err == nil {
+			t.Fatal("expected send error")
+		}
+	})
+}

--- a/adapter/token/jwt/jwt_test.go
+++ b/adapter/token/jwt/jwt_test.go
@@ -1,0 +1,80 @@
+package jwt
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewValidation(t *testing.T) {
+	t.Run("unsupported method", func(t *testing.T) {
+		_, err := New("ES256", nil, "", "")
+		if err == nil {
+			t.Fatal("expected error for unsupported method")
+		}
+	})
+
+	t.Run("missing hmac key", func(t *testing.T) {
+		_, err := New("HS256", nil, "", "")
+		if err == nil {
+			t.Fatal("expected error for missing hmac key")
+		}
+	})
+}
+
+func TestAccessAndRefreshTokenRoundTrip(t *testing.T) {
+	tok, err := New("HS256", []byte("secret-key"), "", "")
+	if err != nil {
+		t.Fatalf("unexpected error creating token adapter: %v", err)
+	}
+
+	expiry := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+
+	accessToken, err := tok.CreateAccessToken("usi-123", "jdoe", "Jane Doe", expiry)
+	if err != nil {
+		t.Fatalf("unexpected error creating access token: %v", err)
+	}
+
+	usi, accessExp, err := tok.GetAccessTokenData(accessToken)
+	if err != nil {
+		t.Fatalf("unexpected error reading access token: %v", err)
+	}
+	if usi != "usi-123" {
+		t.Fatalf("unexpected usi: %s", usi)
+	}
+	if !accessExp.Equal(expiry) {
+		t.Fatalf("unexpected access expiry: got %v want %v", accessExp, expiry)
+	}
+
+	refreshToken, err := tok.CreateRefreshToken("usi-123", expiry)
+	if err != nil {
+		t.Fatalf("unexpected error creating refresh token: %v", err)
+	}
+
+	refreshUSI, refreshExp, err := tok.GetRefreshTokenData(refreshToken)
+	if err != nil {
+		t.Fatalf("unexpected error reading refresh token: %v", err)
+	}
+	if refreshUSI != "usi-123" {
+		t.Fatalf("unexpected refresh usi: %s", refreshUSI)
+	}
+	if !refreshExp.Equal(expiry) {
+		t.Fatalf("unexpected refresh expiry: got %v want %v", refreshExp, expiry)
+	}
+}
+
+func TestTokenTypeMismatch(t *testing.T) {
+	tok, err := New("HS256", []byte("secret-key"), "", "")
+	if err != nil {
+		t.Fatalf("unexpected error creating token adapter: %v", err)
+	}
+
+	refreshToken, err := tok.CreateRefreshToken("usi-123", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("unexpected error creating refresh token: %v", err)
+	}
+
+	_, _, err = tok.GetAccessTokenData(refreshToken)
+	if err == nil {
+		t.Fatal("expected token type mismatch error")
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve unit coverage for core adapters (JWT, zap logger, Kafka producer/consumer) to catch regressions in token handling, logging helpers, and message routing/publishing.

### Description
- Add `adapter/token/jwt/jwt_test.go` with tests for constructor validation, access/refresh token create/parse round-trip, and token type mismatch.
- Add `adapter/logger/zapLogger/zap_test.go` with tests for `stringToZapLevel` and the runtime helper `getFunctionName`.
- Add `adapter/message/kafka/producer/producer_test.go` with a mock `sarama` sync producer to validate published payloads and error paths for marshalling/sending.
- Add `adapter/message/kafka/consumer/consumer_test.go` to exercise routing logic for activation and password-reset messages and invalid input handling.

### Testing
- Formatted new files with `gofmt -w` to ensure consistent style and formatting (succeeded).
- Ran `go test ./...` to execute the test suite but it failed to set up because required Go modules could not be fetched in this environment (network/proxy 403), so package compilation and test execution were blocked.
- Attempted `go mod tidy` to vendor dependencies but it also failed due to remote fetch errors (proxy/network forbidden), so external module resolution remains unresolved in CI-less environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9d4346d4832aa81eb5c99d2b1274)