### PR TITLE
Add GitHub Actions CI workflow with 80% coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Test and Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod tidy
+
+      - name: Run tests with coverage
+        run: go test -mod=mod ./... -covermode=count -coverprofile=coverage.out
+
+      - name: Enforce minimum coverage (80%)
+        run: |
+          total_cov=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%", "", $3); print $3}')
+          echo "Total coverage: ${total_cov}%"
+          awk -v cov="$total_cov" 'BEGIN { if (cov < 80) { printf("Coverage %.2f%% is below 80%%\n", cov); exit 1 } else { printf("Coverage %.2f%% meets requirement\n", cov) } }'


### PR DESCRIPTION
### Motivation
- Provide a CI/CD pipeline so repository tests run automatically on pushes and pull requests.
- Enforce a minimum test coverage threshold (80%) to maintain code quality.

### Description
- Added a new workflow at `.github/workflows/ci.yml` that runs on `push` and `pull_request` events.
- Workflow sets up Go using `actions/setup-go@v5`, runs `go mod tidy`, executes `go test -mod=mod ./... -covermode=count -coverprofile=coverage.out`, and produces a coverage profile.
- The workflow enforces a minimum total coverage of 80% by parsing `coverage.out` with `go tool cover` and failing the job if coverage is below 80%.

### Testing
- Ran `go mod tidy` locally which failed due to blocked access to the module proxy (`proxy.golang.org`) in this environment.
- Ran `go test -mod=mod ./... -covermode=count -coverprofile=coverage.out` locally which also failed due to the same dependency fetch restrictions.
- The workflow is committed and expected to run in GitHub Actions where dependencies should be resolvable and the coverage gate will be enforced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9f37bfb0832a85ff297eb7a65ed6)